### PR TITLE
Feature/Darkmode and Embedding

### DIFF
--- a/CommentWrapper.xcodeproj/project.pbxproj
+++ b/CommentWrapper.xcodeproj/project.pbxproj
@@ -814,7 +814,7 @@
 				);
 				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stevebarnegren.xcodecommentwrapperext;
-				PRODUCT_MODULE_NAME = Comment_Wrapper_Ext;
+				PRODUCT_MODULE_NAME = CommentWrapperExt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "6124f69c-ec06-4601-82c5-7b59a9be6f1c";
 				PROVISIONING_PROFILE_SPECIFIER = "XcodeCommentWrapperExt-macOS-Development";
@@ -840,7 +840,7 @@
 				);
 				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stevebarnegren.xcodecommentwrapperext;
-				PRODUCT_MODULE_NAME = Comment_Wrapper_Ext;
+				PRODUCT_MODULE_NAME = CommentWrapperExt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "09b44ae6-a2ad-462d-b720-4ab39eb1263e";
 				PROVISIONING_PROFILE_SPECIFIER = "XcodeCommentWrapperExt-macOS-AdHoc";

--- a/CommentWrapper.xcodeproj/project.pbxproj
+++ b/CommentWrapper.xcodeproj/project.pbxproj
@@ -49,7 +49,8 @@
 		67A3C0BC207A8B8900E93876 /* Itemizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A3C0B9207A8AE600E93876 /* Itemizer.swift */; };
 		67A3C0BE207A8D3E00E93876 /* CommentUnwrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A3C0BD207A8D3E00E93876 /* CommentUnwrapperTests.swift */; };
 		67A3C0C0207A8D5B00E93876 /* TestStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A3C0BF207A8D5B00E93876 /* TestStrings.swift */; };
-		67ABFBBE25B445EA00DAA9DC /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67ABFBBD25B445EA00DAA9DC /* XcodeKit.framework */; };
+		D4C7432625BC392200C4FE38 /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67ABFBBD25B445EA00DAA9DC /* XcodeKit.framework */; };
+		D4C7432725BC392200C4FE38 /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 67ABFBBD25B445EA00DAA9DC /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,17 @@
 				67A3C09E207822DD00E93876 /* Comment Wrapper.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4C7432825BC392200C4FE38 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D4C7432725BC392200C4FE38 /* XcodeKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -145,8 +157,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				67ABFBBE25B445EA00DAA9DC /* XcodeKit.framework in Frameworks */,
 				67A3C094207822DD00E93876 /* Cocoa.framework in Frameworks */,
+				D4C7432625BC392200C4FE38 /* XcodeKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -325,6 +337,7 @@
 				67A3C08E207822DD00E93876 /* Frameworks */,
 				67A3C08F207822DD00E93876 /* Resources */,
 				675DC4002095B8F7007142A7 /* Set Build Number */,
+				D4C7432825BC392200C4FE38 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/CommentWrapper.xcodeproj/xcshareddata/xcschemes/CommentWrapperExt.xcscheme
+++ b/CommentWrapper.xcodeproj/xcshareddata/xcschemes/CommentWrapperExt.xcscheme
@@ -2,7 +2,7 @@
 <Scheme
    LastUpgradeVersion = "1220"
    wasCreatedForAppExtension = "YES"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -69,18 +69,16 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
-      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "2">
-      <RemoteRunnable
+      allowLocationSimulation = "YES">
+      <PathRunnable
          runnableDebuggingMode = "0"
          BundleIdentifier = "com.apple.dt.Xcode"
-         RemotePath = "/Applications/Xcode.app">
-      </RemoteRunnable>
+         FilePath = "/Applications/Xcode.app">
+      </PathRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/CommentWrapper/About/AboutViewController.swift
+++ b/CommentWrapper/About/AboutViewController.swift
@@ -32,7 +32,7 @@ class AboutViewController: NSViewController {
             
             let text = $0!.title
             let font = $0!.font!
-            let color = NSColor.blue
+            let color = NSColor.linkColor
             
             let attributedString =
                 AttributedStringBuilder()

--- a/CommentWrapper/Base.lproj/Main.storyboard
+++ b/CommentWrapper/Base.lproj/Main.storyboard
@@ -186,7 +186,7 @@
                             </customView>
                             <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c85-CW-ted">
                                 <rect key="frame" x="251" y="360" width="238" height="24"/>
-                                <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="Gto-Cc-orR">
+                                <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="capsule" trackingMode="selectOne" id="Gto-Cc-orR">
                                     <font key="font" metaFont="system"/>
                                     <segments>
                                         <segment label="What" width="77" selected="YES"/>

--- a/CommentWrapper/Content/ContentBuilder.swift
+++ b/CommentWrapper/Content/ContentBuilder.swift
@@ -13,7 +13,7 @@ import AttributedStringBuilder
 class ContentBuilder {
     
     private let stringBuilder = AttributedStringBuilder()
-    private let textColor = NSColor.black
+    private let textColor = NSColor.textColor
     private let codeFont = NSFont(name: "menlo", size: 11.5)!
     
     @discardableResult func title(_ string: String) -> ContentBuilder {

--- a/CommentWrapper/Info.plist
+++ b/CommentWrapper/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2018 Steve Barnegren. All rights reserved.</string>
+	<string>Copyright © 2021 Steve Barnegren. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/CommentWrapperExt/CommentUnwrapper.swift
+++ b/CommentWrapperExt/CommentUnwrapper.swift
@@ -48,7 +48,7 @@ class CommentUnwrapper {
         var reversed = Array(items.reversed())
         while let next = reversed.popLast() {
             
-            //next.debug_print()
+            // next.debug_print()
             
             switch next {
             case .word(let word):

--- a/CommentWrapperExt/CommentWrapper.swift
+++ b/CommentWrapperExt/CommentWrapper.swift
@@ -8,18 +8,6 @@
 
 import Foundation
 
-public extension Array {
-    
-    mutating func popFirst() -> Element? {
-        
-        if self.isEmpty {
-            return nil
-        } else {
-            return self.remove(at: 0)
-        }
-    }
-}
-
 class CommentWrapper {
 
     static func wrap(string: String, lineLength: Int) -> String {

--- a/CommentWrapperExt/CommentWrapper.swift
+++ b/CommentWrapperExt/CommentWrapper.swift
@@ -58,7 +58,7 @@ class CommentWrapper {
         var reversed = Array(items.reversed())
         while let next = reversed.popLast() {
             
-            //next.debug_print()
+            // next.debug_print()
             
             switch next {
             case .word(let word):

--- a/CommentWrapperExt/Info.plist
+++ b/CommentWrapperExt/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>XPC!</string>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>

--- a/CommentWrapperExt/Info.plist
+++ b/CommentWrapperExt/Info.plist
@@ -35,6 +35,6 @@
 		<string>com.apple.dt.Xcode.extension.source-editor</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2018 Steve Barnegren. All rights reserved.</string>
+	<string>Copyright © 2021 Steve Barnegren. All rights reserved.</string>
 </dict>
 </plist>

--- a/CommentWrapperExt/Info.plist
+++ b/CommentWrapperExt/Info.plist
@@ -29,7 +29,7 @@
 			<key>XCSourceEditorCommandDefinitions</key>
 			<array/>
 			<key>XCSourceEditorExtensionPrincipalClass</key>
-			<string>Comment_Wrapper_Ext.SourceEditorExtension</string>
+			<string>$(PRODUCT_MODULE_NAME).SourceEditorExtension</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.dt.Xcode.extension.source-editor</string>

--- a/CommentWrapperExt/SourceEditorCommand.swift
+++ b/CommentWrapperExt/SourceEditorCommand.swift
@@ -11,7 +11,7 @@
 import Foundation
 import XcodeKit
 
-enum Action: String {
+enum Action: String, CaseIterable {
     case wrap40 = "commentwrapper.wrap-40"
     case wrap60 = "commentwrapper.wrap-60"
     case wrap80 = "commentwrapper.wrap-80"
@@ -47,10 +47,6 @@ enum Action: String {
         case .rewrap60: return 60
         case .rewrap80: return 80
         }
-    }
-    
-    static var all: [Action] {
-        return [Action.wrap40, .wrap60, .wrap80, .unwrap, .rewrap40, .rewrap60, .rewrap80]
     }
 }
 

--- a/CommentWrapperExt/SourceEditorExtension.swift
+++ b/CommentWrapperExt/SourceEditorExtension.swift
@@ -18,11 +18,10 @@ class SourceEditorExtension: NSObject, XCSourceEditorExtension {
      */
     
     var commandDefinitions: [[XCSourceEditorCommandDefinitionKey: Any]] {
-        
-        return Action.all
+        return Action.allCases
             .map { [XCSourceEditorCommandDefinitionKey.identifierKey: $0.identifier,
                     XCSourceEditorCommandDefinitionKey.nameKey: $0.name,
-                    XCSourceEditorCommandDefinitionKey.classNameKey: "Comment_Wrapper_Ext.SourceEditorCommand"
+                    XCSourceEditorCommandDefinitionKey.classNameKey: SourceEditorCommand.className()
                 ]}
     }
     


### PR DESCRIPTION
As mentioned in #6

- Adds required Embedding & Signing of XcodeKit.framework
- Fixes Dark Mode Colors and Segmented Control Style
- Fixes Product Module Name for App Extension
- Removes obsolete popFirst and all
- Uses safer className instead of string literal for commandDefinitions
- Removes SwiftLint warnings
- Convenience Launch of App Extension with debuggable Xcode (via xcscheme), automatically creates the "gray" debuggable Xcode instance