### PR TITLE
Detect code blocks and markdown links

### DIFF
--- a/CommentWrapperExt/CommentUnwrapper.swift
+++ b/CommentWrapperExt/CommentUnwrapper.swift
@@ -58,17 +58,17 @@ class CommentUnwrapper {
                 commitPendingSpace()
                 spacePending = true
             case .newline:
-                if let lastItem = lastItem, case .newline = lastItem {
-                    if spacePending {
+                switch lastItem {
+                    case .newline:
+                        if spacePending {
+                            unwrappedString += "\n"
+                            spacePending = false
+                        }
                         unwrappedString += "\n"
-                        spacePending = false
-                    }
-                    
-                    unwrappedString += "\n"
-                } else if let lastItem = lastItem, case .code = lastItem {
-                    unwrappedString += "\n"
-                } else {
-                    spacePending = true
+                    case .code, .markdownReferenceLink:
+                        unwrappedString += "\n"
+                    default:
+                        spacePending = true
                 }
             case .bullet:
                 if spacePending {
@@ -77,9 +77,10 @@ class CommentUnwrapper {
                 }
                 unwrappedString += "-"
                 spacePending = false
-            case .code(let code):
-                unwrappedString.append(contentsOf: code)
+            case .code(let value), .markdownReferenceLink(let value):
+                unwrappedString.append(contentsOf: value)
             }
+            
             
             lastItem = next
         }

--- a/CommentWrapperExt/CommentWrapper.swift
+++ b/CommentWrapperExt/CommentWrapper.swift
@@ -71,6 +71,9 @@ class CommentWrapper {
             case .code(let code):
                 whiteSpace = ""
                 currentLine.append(contentsOf: code)
+            case .markdownReferenceLink(let link):
+                whiteSpace = ""
+                currentLine.append(contentsOf: link)
             }
         }
         

--- a/CommentWrapperExt/CommentWrapper.swift
+++ b/CommentWrapperExt/CommentWrapper.swift
@@ -68,12 +68,9 @@ class CommentWrapper {
             case .bullet:
                 whiteSpace = ""
                 currentLine.append("-")
-            case .code(let code):
+            case .code(let value), .markdownReferenceLink(let value):
                 whiteSpace = ""
-                currentLine.append(contentsOf: code)
-            case .markdownReferenceLink(let link):
-                whiteSpace = ""
-                currentLine.append(contentsOf: link)
+                currentLine.append(contentsOf: value)
             }
         }
         

--- a/CommentWrapperTests/CommentWrapperTests.swift
+++ b/CommentWrapperTests/CommentWrapperTests.swift
@@ -206,4 +206,52 @@ class CommentWrapperTests: XCTestCase {
         let output = CommentWrapper.wrap(string: input, lineLength: 40)
         XCTAssertEqual(output, expected)
     }
+    
+    func testHandlesMarkdownLinks() {
+        
+        let input = """
+            /// iaculis eget vestibulum luctus, finibus quis odio. [Cras][1] sed lectus diam. Sed id luctus diam. Fusce posuere elit nec nisl eleifend, [id][2] interdum velit ornare. Suspendisse non sagittis mauris. Fusce elementum ipsum at ligula porttitor, ut.
+            ///
+            /// ```
+            /// import SpotifyWebAPI
+            ///
+            /// let spotify = SpotifyAPI(
+            ///     authorizationManager: AuthorizationCodeFlowPKCEManager(
+            ///         clientId: "Your Client Id", clientSecret: "Your Client Secret"
+            ///     )
+            /// )
+            /// ```
+            ///
+            /// [1]: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-album-really-long
+            /// [2]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+            /// [3]: https://developer.spotify.com/documentation/general/guides/track-relinking-guide/asdfasdf
+            """
+        
+        let expected = """
+            /// iaculis eget vestibulum luctus, finibus quis odio. [Cras][1]
+            /// sed lectus diam. Sed id luctus diam. Fusce posuere elit nec
+            /// nisl eleifend, [id][2] interdum velit ornare. Suspendisse
+            /// non sagittis mauris. Fusce elementum ipsum at ligula
+            /// porttitor, ut.
+            ///
+            /// ```
+            /// import SpotifyWebAPI
+            ///
+            /// let spotify = SpotifyAPI(
+            ///     authorizationManager: AuthorizationCodeFlowPKCEManager(
+            ///         clientId: "Your Client Id", clientSecret: "Your Client Secret"
+            ///     )
+            /// )
+            /// ```
+            ///
+            /// [1]: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-album-really-long
+            /// [2]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+            /// [3]: https://developer.spotify.com/documentation/general/guides/track-relinking-guide/asdfasdf
+            """
+        
+        let output = CommentWrapper.wrap(string: input, lineLength: 60)
+        XCTAssertEqual(output, expected)
+
+    }
+
 }

--- a/Extensions/String+Extensions.swift
+++ b/Extensions/String+Extensions.swift
@@ -10,6 +10,10 @@ import Foundation
 
 extension String {
     
+    var isCodeFence: Bool {
+        self.trimmingCharacters(in: .whitespacesAndNewlines) == "```"
+    }
+
     func lines() -> [String] {
         
         if self.isEmpty {


### PR DESCRIPTION
These lines should not be wrapped. See the new test for an example.